### PR TITLE
Added Date object support

### DIFF
--- a/paperwork.js
+++ b/paperwork.js
@@ -74,6 +74,9 @@ function paperwork(spec, val, visitor) {
 
   if (spec === Number)
     return visitor.checkType(val, 'number');
+  
+  if (spec === Date)
+    return visitor.checkFun(new Date(val), isValidDate, 'should be a Date');
 
   if (spec === Array)
     return visitor.checkType(val, _.isArray, 'should be an array');
@@ -102,6 +105,10 @@ function paperwork(spec, val, visitor) {
       return paperwork(itemSpec, item, visitor.enterArray(i));
     });
   }
+  
+  if (isValidDate(spec)) {
+    return new Date(val);
+  }
 
   if (_.isObject(spec)) {
     if (!visitor.checkFun(val, _.isObject, 'should be an object'))
@@ -119,6 +126,10 @@ function paperwork(spec, val, visitor) {
 
 function getFunctionName(fun) {
   return fun.name || 'custom validator';
+}
+
+function isValidDate(date) {
+  return (_.isDate(date) && !_.isNaN(date.getTime()));
 }
 
 module.exports = function (spec, blob, done) {

--- a/test/test.js
+++ b/test/test.js
@@ -110,6 +110,39 @@ describe('Paperwork', function () {
       });
     });
   });
+  
+  describe('Date support', function() {
+    var schema = {
+      date: Date
+    }
+    
+    it('should make Date as Date', function(done) {
+      var blob = {
+        date: '2012-04-21T18:25:43-05:00',
+      };
+           
+      paperwork(schema, blob, function (err, validated) {
+        should.not.exist(err);
+        should.exist(validated);
+        validated.date.should.be.an.instanceOf(Date)
+        validated.date.should.eql(new Date(blob.date));        
+        done();
+      });      
+    });
+    
+    it('should fail if there is no valied Date', function(done) {
+      var blob = {
+        date: 'invalid date',
+      };
+
+      paperwork(schema, blob, function (err, validated) {
+        should.exist(err);
+        should.not.exist(validated);
+        err.should.eql(['body.date: should be a Date']);
+        done();
+      });
+    });
+  });
 
   describe('Optional', function () {
     var withOption = {


### PR DESCRIPTION
It checks if Date is valid Date and if so the resulting object will be a Date object.

I suppose if user set some field as **Date**, she expects to have Date object on the output, otherwise she could use **String** type. I think It could be helpful to avoid additional checks and transforms before saving object to MongoDB or something.

Tests provided.
