### PR TITLE
It should use checkFun insted of checkType for Arrays

### DIFF
--- a/paperwork.js
+++ b/paperwork.js
@@ -76,7 +76,7 @@ function paperwork(spec, val, visitor) {
     return visitor.checkType(val, 'number');
 
   if (spec === Array)
-    return visitor.checkType(val, _.isArray, 'should be an array');
+    return visitor.checkFun(val, _.isArray, 'should be an array');
 
   if (spec instanceof Multiple) {
     var allGood = _.all(spec.mult, function (spec) {


### PR DESCRIPTION
When I worked on **date-support** branch I faced with issue when I used same approach as Array has, but later I found `checkFun` function that worked well for Date, and really should be used for Arrays as well (in terms of parameters and so on). 
