### PR TITLE
Set Content-Type header for response to invalid bodies

### DIFF
--- a/paperwork.js
+++ b/paperwork.js
@@ -146,12 +146,13 @@ module.exports.accept = function (spec) {
     }
 
     res.statusCode = 400;
+    res.setHeader('Content-Type', 'application/json');
     var response = {
       status: 'bad_request',
       reason: 'Body did not satisfy requirements',
       errors: visitor.errors
     }
-    res.end(JSON.stringify({status: 'bad_request', reason: 'Body did not satisfy requirements', errors: visitor.errors}, null, '  '))
+    res.end(JSON.stringify(response));
   };
 };
 

--- a/test/test.js
+++ b/test/test.js
@@ -353,7 +353,7 @@ describe('Paperwork', function () {
 
       fakeRes.statusCode.should.equal(400, 'status code should be 400');
       fakeRes.end.called.should.equal(true, 'end() should have been called');
-      fakeRes._getData().should.match(/bad_request/)
+      fakeRes._getData().should.match(/bad_request/);
     });
   });
 


### PR DESCRIPTION
When Paperwork validates a body and then fails (i.e. the body doesn't meet the requirements), the response does not have a `Content-Type` header set. This should really be set to some variation of `application/json` and the response should be sent as proper JSON, not JSON as a preformatted string, which is currently being sent.

By changing [paperwork.js#L154](https://github.com/lperrin/paperwork/blob/master/paperwork.js#L154) to `res.json` instead of `res.end`, Express automatically sets the `Content-Type` to `application/json; charset=utf-8`. I've also updated the tests to check for usage of `json()` instead of `end()`.

For what it's worth, the [Express API guidelines](http://expressjs.com/api.html#res.end) actually say *not* to use `res.end()` if you need to send data.